### PR TITLE
Add IGs for ballot Juni 2026 to fhir.ch index

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,13 +220,24 @@ gtag('config', 'G-ED8VLFMEVY');
     
                 <h5>CH EPR FHIR</h5>
                 <p>
-                    This national extension provides a FHIR based API for the Swiss EPR by extending the IHE FHIR based mobile profiles. 
+                    This national extension provides a FHIR based API for the Swiss EPR by extending the IHE FHIR based mobile profiles.
                     <br />
                     <a href="/ig/ch-epr-fhir/index.html">Implementation Guide</a>&nbsp;&nbsp;|&nbsp;&nbsp;
                     <a href="http://build.fhir.org/ig/ehealthsuisse/ch-epr-fhir/index.html">CI Build</a> &nbsp;&nbsp;|&nbsp;&nbsp;
                     <a href="/ig/ch-epr-fhir/history.html">Publication History</a>&nbsp;&nbsp;|&nbsp;&nbsp;
                     <a href="https://github.com/ehealthsuisse/ch-epr-fhir">Source</a> &nbsp;&nbsp;|&nbsp;&nbsp;
                     <a href="mailto:martin.smock@e-health-suisse.ch">Contact</a>
+                </p>
+
+                <h5>CH EMR</h5>
+                <p>
+                    FHIR Implementation Guide for the Swiss Electronic Emergency Record.
+                    <br />
+                    <a href="/ig/ch-emr/index.html">Implementation Guide</a>&nbsp;&nbsp;|&nbsp;&nbsp;
+                    <a href="http://build.fhir.org/ig/hl7ch/ch-emr/index.html">CI Build</a> &nbsp;&nbsp;|&nbsp;&nbsp;
+                    <a href="/ig/ch-emr/history.html">Publication History</a>&nbsp;&nbsp;|&nbsp;&nbsp;
+                    <a href="https://github.com/hl7ch/ch-emr">Source</a> &nbsp;&nbsp;|&nbsp;&nbsp;
+                    <a href="https://www.e-health-suisse.ch/">Contact</a>
                 </p>
 
                 <p> <br />
@@ -309,11 +320,33 @@ gtag('config', 'G-ED8VLFMEVY');
                 
                 <h5>MedNet Interface IG</h5>
                 <p>
-                    This Implementation Guides describes the bundle that can be used to transfer patient information to MedNet, providing an optimized pre-filling of all forms. 
+                    This Implementation Guides describes the bundle that can be used to transfer patient information to MedNet, providing an optimized pre-filling of all forms.
                     <br />
-                    <a href="https://doc.mednet.swiss/fhir/index.html">Implementation Guide</a>&nbsp;&nbsp;|&nbsp;&nbsp; 
-                    <a href="https://doc.mednet.swiss/fhir/history.html">Publication History</a>&nbsp;&nbsp;|&nbsp;&nbsp;                    
+                    <a href="https://doc.mednet.swiss/fhir/index.html">Implementation Guide</a>&nbsp;&nbsp;|&nbsp;&nbsp;
+                    <a href="https://doc.mednet.swiss/fhir/history.html">Publication History</a>&nbsp;&nbsp;|&nbsp;&nbsp;
                     <a href="https://www.openmedical.swiss/#contact">Contact</a>
+                </p>
+
+                <h5>CH ALIS Connect</h5>
+                <p>
+                    Implementation Guide for ALIS-Connect.
+                    <br />
+                    <a href="/ig/ch-alis-connect/index.html">Implementation Guide</a>&nbsp;&nbsp;|&nbsp;&nbsp;
+                    <a href="http://build.fhir.org/ig/hl7ch/ch-alis-connect/index.html">CI Build</a> &nbsp;&nbsp;|&nbsp;&nbsp;
+                    <a href="/ig/ch-alis-connect/history.html">Publication History</a>&nbsp;&nbsp;|&nbsp;&nbsp;
+                    <a href="https://github.com/hl7ch/ch-alis-connect">Source</a> &nbsp;&nbsp;|&nbsp;&nbsp;
+                    <a href="https://www.alis-connect.ch/">Contact</a>
+                </p>
+
+                <h5>CH IDMP</h5>
+                <p>
+                    IDMP Base Implementation Guide for Swissmedic. FHIR Implementation Guide for medicinal product authorization, supporting data exchange between Marketing Authorization Holders (MAHs) and Swissmedic, and the introduction of the ISO IDMP standards in Switzerland.
+                    <br />
+                    <a href="/ig/ch-idmp/index.html">Implementation Guide</a>&nbsp;&nbsp;|&nbsp;&nbsp;
+                    <a href="http://build.fhir.org/ig/seicodyne/ch-idmp/index.html">CI Build</a> &nbsp;&nbsp;|&nbsp;&nbsp;
+                    <a href="/ig/ch-idmp/history.html">Publication History</a>&nbsp;&nbsp;|&nbsp;&nbsp;
+                    <a href="https://github.com/seicodyne/ch-idmp">Source</a> &nbsp;&nbsp;|&nbsp;&nbsp;
+                    <a href="https://www.refdata.ch/de/">Refdata Foundation</a>
                 </p>
 
                 <p><br /><br /></p>


### PR DESCRIPTION
Adds the 3 newly published 2026 ballot IGs to the fhir.ch landing page index.

- **CH EMR** → under *by eHealth Suisse*
- **CH ALIS Connect** → under *by other organizations*
- **CH IDMP** → under *by other organizations* (Refdata Foundation publisher)

Follow-up for CH EMS and CH UMZH Connect once their ballots are published.