### PR TITLE
Auto-shutoff ballot UI by date

### DIFF
--- a/WEBSITE_QUICKSTART.md
+++ b/WEBSITE_QUICKSTART.md
@@ -71,6 +71,22 @@ An internet connection is required — the catalog data is fetched at load time,
 
 Set `BALLOT_CYCLE = null` in `js/load-data.js`. That's it — the hero Register button hides, "Join FHIR.ch work group calls" goes back to primary, and every per-IG VOTE chip disappears. No other edits needed.
 
+#### Auto-shutoff by date (optional)
+
+Two ISO-date fields on `BALLOT_CYCLE` let registration and voting expire on their own — useful when registration closes weeks before voting:
+
+```js
+var BALLOT_CYCLE = {
+  year:                '2026',
+  registrationCloses:  '2026-08-03',   // hero Register button hides 2026-08-04
+  votingCloses:        '2026-09-30',   // all VOTE chips hide 2026-10-01
+  registrationFormId:  '…',
+  forms: { … }
+};
+```
+
+Both fields are INCLUSIVE (the day named is still active; the UI piece hides starting the day after) and use the browser's local date. Either is optional — omit one to keep that piece live until you flip `BALLOT_CYCLE = null` by hand. The forms themselves should still be closed in Google Drive ("Accepting responses" off) as the authoritative kill switch; these dates only handle the UI.
+
 > **Dev-mode sanity check.** When you're running on `localhost` / `127.0.0.1` / `file://`, the page prints `[ballot-cycle]` warnings to the browser console for any drift between `BALLOT_CYCLE` and the catalog data: `BALLOT_CYCLE` is `null` while IGs are still under-ballot, an under-ballot IG has no form entry, a `BALLOT_CYCLE.forms` key is stale / a typo / references a now-published IG, or `BALLOT_CYCLE.year` doesn't match any IG's `ballotCloses` year. Open devtools after any edit and you'll see what to fix. Production hostnames stay silent.
 
 ### Curate an IG (workgroup, organization, description, ballot dates)

--- a/WEBSITE_README.md
+++ b/WEBSITE_README.md
@@ -81,7 +81,11 @@ The loader is the single source of curated overlay on top of the upstream JSON:
   - `links` — `{source, wiki, jira}`; override the default `github.com/hl7ch/{slug}` derivation.
   - `publicationStatus: 'published'` — force-promote an upstream entry tagged `ballot` to published (currently used only by `ch-epr-fhir`).
 - **`EXTRA_IGS`** — array of fully-specified IG entries appended to the catalog. Use this only for IGs upstream does not yet list (currently Swissnoso and MedNet Interface). Copy an existing entry as the template — every field shown there is required.
-- **`BALLOT_CYCLE`** — single object that owns the current ballot cycle: the year, the registration form Drive id, and the per-IG form Drive ids. Drives both the green **VOTE** chip on each open ballot row and the blue **Register to vote · Ballot YYYY →** hero button. Set to `null` between cycles. See [Updating the ballot vote forms](#updating-the-ballot-vote-forms) for the per-cycle procedure.
+- **`BALLOT_CYCLE`** — single object that owns the current ballot cycle: the year, the registration form Drive id, and the per-IG form Drive ids. Drives both the green **VOTE** chip on each open ballot row and the blue **Register to vote · Ballot YYYY →** hero button. Set to `null` between cycles. Two optional ISO-date fields auto-shut-off pieces of the UI when their deadline passes (both INCLUSIVE — UI hides starting the day after):
+  - **`registrationCloses`** — hides the hero Register button once past.
+  - **`votingCloses`** — empties `forms` (every VOTE chip disappears) once past.
+
+  See [Updating the ballot vote forms](#updating-the-ballot-vote-forms) for the per-cycle procedure.
 - **`ORG_NAMES`** and **`ORG_ORDER`** — display name per organization `id`. The `id` keys are what `OVERRIDES.organization` references. IGs with no `organization` override and no fallback signal default to `'hl7ch'`.
 - **`WG_*` shorthands** — reusable workgroup objects. Add new ones rather than inlining `{name, url}` literals.
 

--- a/js/load-data.js
+++ b/js/load-data.js
@@ -35,6 +35,10 @@
   // both vanish, no other edits required. See QUICKSTART.md.
   var BALLOT_CYCLE = {
     year:                '2026',
+    // Auto-shutoff dates (browser-local date, ISO YYYY-MM-DD, INCLUSIVE — UI
+    // hides starting the day AFTER). Source: HL7.ch 2026 ballot calendar.
+    registrationCloses:  '2026-08-03',   // End of registration → hero Register button hides 2026-08-04
+    votingCloses:        '2026-09-30',   // End of voting → every per-IG VOTE chip hides 2026-10-01
     registrationFormId:  '13zN8gpFz_XjTDf3MZHo8E0SL9xjj8TJQ8AxcZQONOwY',
     forms: {
       'ch.fhir.ig.ch-alis-connect': '1Ge_9fwM_yd3ZaLBwumlQuMzlz1AaZi1RAAeMw6RlDds',
@@ -47,6 +51,22 @@
     }
   };
   // var BALLOT_CYCLE = null;   // ← uncomment when the cycle closes
+
+  // Auto-disable past-deadline pieces. Each *Closes day is INCLUSIVE — the UI
+  // hides starting the day AFTER. Browser-local date (Swiss time for most
+  // visitors). Leave a *Closes field unset to keep that piece enabled manually.
+  if (BALLOT_CYCLE) {
+    var _today = (function () {
+      var d = new Date(), m = d.getMonth() + 1, day = d.getDate();
+      return d.getFullYear() + '-' + (m < 10 ? '0' : '') + m + '-' + (day < 10 ? '0' : '') + day;
+    })();
+    if (BALLOT_CYCLE.registrationCloses && _today > BALLOT_CYCLE.registrationCloses) {
+      BALLOT_CYCLE.registrationFormId = null;
+    }
+    if (BALLOT_CYCLE.votingCloses && _today > BALLOT_CYCLE.votingCloses) {
+      BALLOT_CYCLE.forms = {};
+    }
+  }
 
   var BALLOT_VOTE_FORMS = (BALLOT_CYCLE && BALLOT_CYCLE.forms) || {};
   function voteFormUrl(id) { return 'https://docs.google.com/forms/d/' + id + '/viewform'; }


### PR DESCRIPTION
Add two optional ISO-date fields to `BALLOT_CYCLE` in `js/load-data.js` so registration and voting expire on their own — no manual edit needed at each deadline.

- `registrationCloses` — hides the hero **Register to vote** button starting the day after this date.
- `votingCloses` — clears `forms`, so every per-IG **VOTE** chip disappears starting the day after this date.

Both dates are INCLUSIVE (the day named is still active). Uses the browser's local date.

Wired to the 2026 HL7.ch ballot calendar:
- `registrationCloses: '2026-08-03'` → Register button hides 2026-08-04
- `votingCloses: '2026-09-30'` → VOTE chips hide 2026-10-01

The Google Forms themselves remain the authoritative kill switch (`Accepting responses` toggle on each form). These dates only handle the UI.

`WEBSITE_README.md` and `WEBSITE_QUICKSTART.md` updated with the new fields.