### PR TITLE
Disable ballot UI outside the cycle window

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -204,6 +204,11 @@ button { font-family: inherit; }
 .btn.primary { background: #1f5aa6; color: #fff; border: 1px solid #1f5aa6; }
 .btn.outline { background: #fff; color: #0f172a; border: 1px solid #cbd5e1; }
 .btn.ghost   { background: transparent; color: #1f5aa6; border: none; }
+.btn.disabled {
+  background: #94a3b8; color: #f8fafc; border-color: #94a3b8;
+  cursor: not-allowed; pointer-events: auto;  /* keep tooltip on hover */
+  opacity: 0.7;
+}
 
 /* Stats cards */
 .stats {
@@ -547,6 +552,8 @@ button { font-family: inherit; }
 .chip.secondary { background: #fff;    color: #0c2a4d; border-color: #cbd5e1; }
 .chip.ghost     { background: #f4f6f8; color: #475569; border-color: #e2e8f0; }
 .chip.danger    { background: #d62828; color: #fff;    border-color: #d62828; }
+.chip.disabled  { background: #cbd5e1; color: #64748b; border-color: #cbd5e1;
+                  cursor: not-allowed; opacity: 0.75; }
 
 /* Empty state */
 .empty-state {

--- a/js/app.js
+++ b/js/app.js
@@ -36,6 +36,13 @@
     return `${String(d.getDate()).padStart(2,'0')} ${MONTHS[d.getMonth()]} ${d.getFullYear()}`;
   }
 
+  // Swiss / German calendar style: 'YYYY-MM-DD' → 'DD.MM.YYYY'. Used for
+  // ballot-cycle tooltips so dates match the HL7.ch ballot calendar.
+  function fmtDateDe(iso) {
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso || '');
+    return m ? `${m[3]}.${m[2]}.${m[1]}` : iso;
+  }
+
   function escapeHtml(s) {
     return String(s == null ? '' : s)
       .replace(/&/g, '&amp;')
@@ -229,16 +236,21 @@
       + `<span class="icon">${chip.icon}</span><span>${escapeHtml(chip.label)}</span></a>`;
   }
 
+  function renderDisabledChip(chip, tooltip) {
+    return `<span class="${chip.cls} disabled" title="${escapeHtml(tooltip)}" aria-disabled="true">`
+      + `<span class="icon">${chip.icon}</span><span>${escapeHtml(chip.label)}</span></span>`;
+  }
+
   function renderVersionRow(v) {
     const badge = badgeForVersion(v);
     const chips = [renderChip(versionChip(v))];
     if (v.voteForm) {
-      chips.push(renderChip({
-        cls:   'chip primary',
-        icon:  '✓',
-        label: 'VOTE',
-        url:   v.voteForm
-      }));
+      const cycle = window.FHIR_CH_BALLOT_CYCLE || {};
+      const voteChip = { cls: 'chip primary', icon: '✓', label: 'VOTE', url: v.voteForm };
+      let tooltip = null;
+      if (cycle.votingDisabledUntil) tooltip = `Voting opens ${fmtDateDe(cycle.votingDisabledUntil)}`;
+      else if (cycle.votingDisabledSince) tooltip = `Voting closed ${fmtDateDe(cycle.votingDisabledSince)}`;
+      chips.push(tooltip ? renderDisabledChip(voteChip, tooltip) : renderChip(voteChip));
     }
     const fhirStr = (v.fhirVersion || []).join(', ') || '—';
     const cls = (v.publicationStatus || '').replace(/[^a-z-]/g, '');
@@ -432,17 +444,32 @@
 
   // ─── Hero ballot toggle ─────────────────────────────────────────
   // Reads window.FHIR_CH_BALLOT_CYCLE (set synchronously by load-data.js).
-  // Active cycle → Register button visible + primary; Join demoted to outline.
-  // No cycle → Register hidden; Join restored to primary with trailing arrow.
+  // Cycle present + window open  → Register button active + primary; Join outline.
+  // Cycle present + pre-open     → Register button DISABLED, "opens DD.MM.YYYY".
+  // Cycle present + post-close   → Register button DISABLED, "closed DD.MM.YYYY".
+  // No cycle (BALLOT_CYCLE=null) → Register button hidden; Join restored to primary.
   function applyBallotCycle() {
     const cycle = window.FHIR_CH_BALLOT_CYCLE;
     const vote  = document.getElementById('hero-vote-btn');
     const join  = document.getElementById('hero-join-btn');
     if (!vote || !join) return;
     if (cycle && cycle.registrationFormId) {
-      vote.href        = `https://docs.google.com/forms/d/${cycle.registrationFormId}/viewform`;
+      let tooltip = null;
+      if (cycle.registrationDisabledUntil) tooltip = `Registration opens ${fmtDateDe(cycle.registrationDisabledUntil)}`;
+      else if (cycle.registrationDisabledSince) tooltip = `Registration closed ${fmtDateDe(cycle.registrationDisabledSince)}`;
       vote.textContent = `Register to vote · Ballot ${cycle.year} →`;
       vote.hidden      = false;
+      if (tooltip) {
+        vote.removeAttribute('href');
+        vote.classList.add('disabled');
+        vote.setAttribute('aria-disabled', 'true');
+        vote.title = tooltip;
+      } else {
+        vote.href = `https://docs.google.com/forms/d/${cycle.registrationFormId}/viewform`;
+        vote.classList.remove('disabled');
+        vote.removeAttribute('aria-disabled');
+        vote.removeAttribute('title');
+      }
       join.classList.remove('primary');
       join.classList.add('outline');
       join.textContent = 'Join FHIR.ch work group calls';

--- a/js/load-data.js
+++ b/js/load-data.js
@@ -35,10 +35,13 @@
   // both vanish, no other edits required. See QUICKSTART.md.
   var BALLOT_CYCLE = {
     year:                '2026',
-    // Auto-shutoff dates (browser-local date, ISO YYYY-MM-DD, INCLUSIVE — UI
-    // hides starting the day AFTER). Source: HL7.ch 2026 ballot calendar.
-    registrationCloses:  '2026-08-03',   // End of registration → hero Register button hides 2026-08-04
-    votingCloses:        '2026-09-30',   // End of voting → every per-IG VOTE chip hides 2026-10-01
+    // Auto-window dates (browser-local date, ISO YYYY-MM-DD, both endpoints
+    // INCLUSIVE). Source: HL7.ch 2026 ballot calendar. Outside the window
+    // the matching UI renders DISABLED with a tooltip; it never disappears.
+    registrationOpens:   '2026-06-22',   // Mo, 22.06.2026: Publikation der FHIR IGs → hero Register button active
+    registrationCloses:  '2026-08-03',   // End of registration → hero Register button greyed 2026-08-04
+    votingOpens:         '2026-08-04',   // Di, 04.08.2026: Start Abstimmungsperiode → per-IG VOTE chips active
+    votingCloses:        '2026-09-30',   // End of voting → every per-IG VOTE chip greyed 2026-10-01
     registrationFormId:  '13zN8gpFz_XjTDf3MZHo8E0SL9xjj8TJQ8AxcZQONOwY',
     forms: {
       'ch.fhir.ig.ch-alis-connect': '1Ge_9fwM_yd3ZaLBwumlQuMzlz1AaZi1RAAeMw6RlDds',
@@ -52,19 +55,28 @@
   };
   // var BALLOT_CYCLE = null;   // ← uncomment when the cycle closes
 
-  // Auto-disable past-deadline pieces. Each *Closes day is INCLUSIVE — the UI
-  // hides starting the day AFTER. Browser-local date (Swiss time for most
-  // visitors). Leave a *Closes field unset to keep that piece enabled manually.
+  // Auto-window the ballot UI. Browser-local date (Swiss time for most
+  // visitors). Each endpoint is INCLUSIVE. Leave any *Opens / *Closes field
+  // unset to disable that bound. UI renders DISABLED (greyed, tooltip-only,
+  // non-clickable) both before *Opens and after *Closes — never hidden, so
+  // visitors always see the cycle's context. Set BALLOT_CYCLE = null to
+  // wipe the cycle entirely (e.g. months after it closes).
   if (BALLOT_CYCLE) {
     var _today = (function () {
       var d = new Date(), m = d.getMonth() + 1, day = d.getDate();
       return d.getFullYear() + '-' + (m < 10 ? '0' : '') + m + '-' + (day < 10 ? '0' : '') + day;
     })();
+    if (BALLOT_CYCLE.registrationOpens && _today < BALLOT_CYCLE.registrationOpens) {
+      BALLOT_CYCLE.registrationDisabledUntil = BALLOT_CYCLE.registrationOpens;
+    }
+    if (BALLOT_CYCLE.votingOpens && _today < BALLOT_CYCLE.votingOpens) {
+      BALLOT_CYCLE.votingDisabledUntil = BALLOT_CYCLE.votingOpens;
+    }
     if (BALLOT_CYCLE.registrationCloses && _today > BALLOT_CYCLE.registrationCloses) {
-      BALLOT_CYCLE.registrationFormId = null;
+      BALLOT_CYCLE.registrationDisabledSince = BALLOT_CYCLE.registrationCloses;
     }
     if (BALLOT_CYCLE.votingCloses && _today > BALLOT_CYCLE.votingCloses) {
-      BALLOT_CYCLE.forms = {};
+      BALLOT_CYCLE.votingDisabledSince = BALLOT_CYCLE.votingCloses;
     }
   }
 


### PR DESCRIPTION
Adds `registrationOpens` / `votingOpens` to `BALLOT_CYCLE`. Outside the window the Register button and per-IG VOTE chips render greyed-out with a tooltip ("Voting opens 04.08.2026", "Registration closed 03.08.2026", etc.) instead of disappearing — vanishing read as a bug. `BALLOT_CYCLE = null` still wipes the cycle entirely.